### PR TITLE
Run install_files on post install

### DIFF
--- a/inc/composer/class-plugin.php
+++ b/inc/composer/class-plugin.php
@@ -26,7 +26,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 	public static function getSubscribedEvents() : array {
 		return [
 			'post-update-cmd' => [ 'install_files' ],
-			'pre-install-cmd' => [ 'install_files' ],
+			'post-install-cmd' => [ 'install_files' ],
 		];
 	}
 


### PR DESCRIPTION
Previously we were runing on `pre-install-cmd` which is `occurs before the install command is executed with a lock file present.`. A plugin using that hook is never actually going to get fired, unless a copy of the plugin already exists in `vendor`, which mostly it won't if this is an install from a lock file.

Instead use post-install which fires after everything (including the plugin) has been installed.