### PR TITLE
Add chassis and vendor to default gitignore

### DIFF
--- a/inc/composer/class-plugin.php
+++ b/inc/composer/class-plugin.php
@@ -48,7 +48,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 				'wordpress',
 				'index.php',
 				'wp-config.php',
-				'chassis*',
+				'chassis',
 				'vendor',
 			];
 			file_put_contents( $dest . '/.gitignore', implode( "\n", $entries ) );

--- a/inc/composer/class-plugin.php
+++ b/inc/composer/class-plugin.php
@@ -48,7 +48,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 				'wordpress',
 				'index.php',
 				'wp-config.php',
-				'chassis',
+				'chassis*',
 				'vendor',
 			];
 			file_put_contents( $dest . '/.gitignore', implode( "\n", $entries ) );

--- a/inc/composer/class-plugin.php
+++ b/inc/composer/class-plugin.php
@@ -43,7 +43,15 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 		// Update the .gitignore to include the wp-config.php, WordPress, the index.php
 		// as these files should not be included in VCS.
 		if ( ! file_exists( $dest . '/.gitignore' ) ) {
-			file_put_contents( $dest . '/.gitignore', "wordpress/\nindex.php\nwp-config.php" );
+			$entries = [
+				'# Altis',
+				'wordpress',
+				'index.php',
+				'wp-config.php',
+				'chassis',
+				'vendor',
+			];
+			file_put_contents( $dest . '/.gitignore', implode( "\n", $entries ) );
 		}
 
 		if ( ! is_dir( $dest . '/content' ) ) {


### PR DESCRIPTION
The vendor and chassis directories are supplied by Altis but shouldn't be committed so we should ignore those.

Fixes #12 