### PR TITLE
Don't load WP in unit test context

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -66,4 +66,6 @@ foreach ( $required_constants as $constant ) {
 	}
 }
 
-require_once ABSPATH . 'wp-settings.php';
+if ( ! defined( 'PHPUNIT_COMPOSER_INSTALL' ) ) {
+	require_once ABSPATH . 'wp-settings.php';
+}

--- a/wp-config.php
+++ b/wp-config.php
@@ -66,6 +66,6 @@ foreach ( $required_constants as $constant ) {
 	}
 }
 
-if ( ! defined( 'PHPUNIT_COMPOSER_INSTALL' ) ) {
+if ( ! getenv( 'WP_PHPUNIT__TESTS_CONFIG' ) ) {
 	require_once ABSPATH . 'wp-settings.php';
 }


### PR DESCRIPTION
This makes it easy to include the altis wp-config.php when running unit tests.