### PR TITLE
Use platform-independent directory separator

### DIFF
--- a/inc/composer/class-plugin.php
+++ b/inc/composer/class-plugin.php
@@ -92,9 +92,12 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 			}
 
 			// Determine absolute file path.
-			$default_base = $vendor_dir . DIRECTORY_SEPARATOR . str_replace( '/', DIRECTORY_SEPARATOR, $package->getName() );
+			// Note: we use / instead of the platform-dependent directory
+			// separator as it needs to work cross-platform (e.g. Windows host,
+			// Linux VM)
+			$default_base = $vendor_dir . '/' . str_replace( DIRECTORY_SEPARATOR, '/', $package->getName() );
 			$base = $package->getTargetDir() ?? $default_base;
-			$file = $base . DIRECTORY_SEPARATOR . 'load.php';
+			$file = $base . '/' . 'load.php';
 
 			if ( ! file_exists( $file ) ) {
 				continue;


### PR DESCRIPTION
When installing on a Windows host, `modules.php` will be generated with lines like `require_once dirname( __DIR__ ) . '\altis\cms\load.php'`. This works on the host, but not inside the VM/container.

`/` is a universal path separator that can be used on any platform, so this PR replaces it with that. (Ironically, it's our use of the "correct" `DIRECTORY_SEPARATOR` that was breaking this here.)