### PR TITLE
Ensure altis/cms is installed prior to copying files.

### DIFF
--- a/inc/composer/class-plugin.php
+++ b/inc/composer/class-plugin.php
@@ -54,8 +54,11 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 		$source = $this->composer->getConfig()->get( 'vendor-dir' ) . '/altis/cms';
 		$dest   = dirname( $this->composer->getConfig()->get( 'vendor-dir' ) );
 
-		copy( $source . '/index.php', $dest . '/index.php' );
-		copy( $source . '/wp-config.php', $dest . '/wp-config.php' );
+		// Ensure altis/cms is installed.
+		if ( file_exists( $source . '/index.php' ) ) {
+			copy( $source . '/index.php', $dest . '/index.php' );
+			copy( $source . '/wp-config.php', $dest . '/wp-config.php' );
+		}
 
 		// Copy build script file if one doesn't exist.
 		if ( ! file_exists( $dest . '/.build-script' ) ) {

--- a/inc/composer/class-plugin.php
+++ b/inc/composer/class-plugin.php
@@ -55,7 +55,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 		$dest   = dirname( $this->composer->getConfig()->get( 'vendor-dir' ) );
 
 		// Bail if altis/cms isn't installed, unpredictable environment.
-		if ( file_exists( $source . '/index.php' ) ) {
+		if ( ! file_exists( $source . '/index.php' ) ) {
 			return;
 		}
 

--- a/inc/composer/class-plugin.php
+++ b/inc/composer/class-plugin.php
@@ -54,11 +54,13 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 		$source = $this->composer->getConfig()->get( 'vendor-dir' ) . '/altis/cms';
 		$dest   = dirname( $this->composer->getConfig()->get( 'vendor-dir' ) );
 
-		// Ensure altis/cms is installed.
+		// Bail if altis/cms isn't installed, unpredictable environment.
 		if ( file_exists( $source . '/index.php' ) ) {
-			copy( $source . '/index.php', $dest . '/index.php' );
-			copy( $source . '/wp-config.php', $dest . '/wp-config.php' );
+			return;
 		}
+
+		copy( $source . '/index.php', $dest . '/index.php' );
+		copy( $source . '/wp-config.php', $dest . '/wp-config.php' );
 
 		// Copy build script file if one doesn't exist.
 		if ( ! file_exists( $dest . '/.build-script' ) ) {


### PR DESCRIPTION
This modifies the installation process to ensure that `alits/cms/index.php` exists before attempting to copy both `index.php` and `wp-config.php` (if the former exists, the latter can be assumed to exist).

The primary purpose of this is for Altish environments using `johnpbloch/wordpress` rather than `alits/cms`. On such an environment I've been using 0.3.2 to avoid the cross-library reference. Unfortunately this is no longer viable as it requires composer 1 and the packagist endpoints are due to be [shut down later this year](https://blog.packagist.com/shutting-down-packagist-org-support-for-composer-1-x/).

Related #29.